### PR TITLE
Add dyn keyword to fix clippy lints

### DIFF
--- a/test_suite/src/main.rs
+++ b/test_suite/src/main.rs
@@ -15,7 +15,7 @@ pub struct Config {
 
 // Ensure custom Result can be defined in the current context.
 // See: https://github.com/greyblake/envconfig-rs/issues/21
-type Result<T> = std::result::Result<T, Box<std::error::Error>>;
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 fn main() {
     let res: Result<i32> = Ok(123);


### PR DESCRIPTION
It looks like your ci builds are failing on a clippy lint. This should fix that error.