### PR TITLE
Change from failure to thiserror

### DIFF
--- a/envconfig/Cargo.toml
+++ b/envconfig/Cargo.toml
@@ -11,8 +11,8 @@ homepage = "https://github.com/greyblake/envconfig-rs"
 documentation = "https://docs.rs/envconfig"
 readme = "README.md"
 
-[dependencies]
-failure = "0.1.2"
-
 [dev-dependencies]
 envconfig_derive = { version = "0.6.0", path = "../envconfig_derive" }
+
+[dependencies]
+thiserror = "1.0.9"

--- a/envconfig/src/error.rs
+++ b/envconfig/src/error.rs
@@ -1,8 +1,10 @@
+use thiserror::Error;
+
 /// Represents an error, that may be returned by `fn init()` of trait `Envconfig`.
-#[derive(Debug, Fail, PartialEq)]
+#[derive(Debug, PartialEq, Error)]
 pub enum Error {
-    #[fail(display = "Env variable is missing: {}", name)]
+    #[error("Env variable is missing: {name:?}")]
     EnvVarMissing { name: &'static str },
-    #[fail(display = "Failed to parse env variable: {}", name)]
+    #[error("Failed to parse env variable: {name:?}")]
     ParseError { name: &'static str },
 }

--- a/envconfig/src/lib.rs
+++ b/envconfig/src/lib.rs
@@ -42,8 +42,7 @@
 //! data type. So, if your data type does not implement `std::str::FromStr` the program
 //! will not compile.
 
-#[macro_use]
-extern crate failure;
+extern crate thiserror;
 
 mod error;
 mod traits;


### PR DESCRIPTION
`thiserror` has fewer dependencies (see trees below) and uses `std::error::Error` which makes it easy to integrate with other error handling crates. The main reason for this PR is that I met some issues because `Fail` does not implemented `std::error::Error` which is very limiting when using `?` with generic errors.

### Dependency tree before

```
envconfig v0.6.0 (/home/oruud/Programming/envconfig-rs/envconfig)
└── failure v0.1.6
    ├── backtrace v0.3.42
    │   ├── backtrace-sys v0.1.32
    │   │   └── libc v0.2.66
    │   │   [build-dependencies]
    │   │   └── cc v1.0.50
    │   ├── cfg-if v0.1.10
    │   ├── libc v0.2.66 (*)
    │   └── rustc-demangle v0.1.16
    └── failure_derive v0.1.6
        ├── proc-macro2 v1.0.8
        │   └── unicode-xid v0.2.0
        ├── quote v1.0.2
        │   └── proc-macro2 v1.0.8 (*)
        ├── syn v1.0.14
        │   ├── proc-macro2 v1.0.8 (*)
        │   ├── quote v1.0.2 (*)
        │   └── unicode-xid v0.2.0 (*)
        └── synstructure v0.12.3
            ├── proc-macro2 v1.0.8 (*)
            ├── quote v1.0.2 (*)
            ├── syn v1.0.14 (*)
            └── unicode-xid v0.2.0 (*)
```

### Dependency tree after

```
envconfig v0.6.0 (/home/oruud/Programming/envconfig-rs/envconfig)
└── thiserror v1.0.9
    └── thiserror-impl v1.0.9
        ├── proc-macro2 v1.0.8
        │   └── unicode-xid v0.2.0
        ├── quote v1.0.2
        │   └── proc-macro2 v1.0.8 (*)
        └── syn v1.0.14
            ├── proc-macro2 v1.0.8 (*)
            ├── quote v1.0.2 (*)
            └── unicode-xid v0.2.0 (*)
```
