### PR TITLE
Update syn, quote, proc-macro2 to 1.x versions

### DIFF
--- a/envconfig_derive/Cargo.toml
+++ b/envconfig_derive/Cargo.toml
@@ -15,6 +15,6 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
-syn = "0.15.4"
-quote = "0.6.8"
-proc-macro2 = "0.4.19"
+syn = "1.0.17"
+quote = "1.0.3"
+proc-macro2 = "1.0.9"

--- a/envconfig_derive/src/lib.rs
+++ b/envconfig_derive/src/lib.rs
@@ -127,10 +127,11 @@ fn fetch_envconfig_attr_from_field(field: &Field) -> Option<&Attribute> {
 }
 
 fn fetch_list_from_attr(field: &Field, attr: &Attribute) -> Punctuated<NestedMeta, Comma> {
-    let opt_meta = attr.interpret_meta().unwrap_or_else(|| {
+    let opt_meta = attr.parse_meta().unwrap_or_else(|err| {
         panic!(
-            "Can not interpret meta of `envconfig` attribute on field `{}`",
-            field_name(field)
+            "Can not interpret meta of `envconfig` attribute on field `{}`: {}",
+            field_name(field),
+            err
         )
     });
 
@@ -176,11 +177,7 @@ fn find_item_in_list<'l, 'n>(
                 field_name(field)
             ),
         })
-        .find(|name_value| {
-            let ident = &name_value.ident;
-            let name = quote!(#ident).to_string();
-            name == item_name
-        })
+        .find(|name_value| name_value.path.is_ident(item_name))
         .map(|item| &item.lit)
 }
 


### PR DESCRIPTION
This crate was the only one in a bigger project of mine that was still on 0.x versions of those crate.

Improves build times and reduces total number of dependencies from 73 -> 65 ;)