### PR TITLE
feat: Add "env_prefix" attribute for struct derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Environment variable can be automatically derived from a field name (e.g. `db_host` will be tried to loaded from `DB_HOST` env var)
 * Add install step in README
 
+#### v0.10.1 - 2023-04-23
+* Add envconfig annotation for top-level (non-nested) structs with `env_prefix` attribute
+
 #### v0.10.0 - 2021-06-8
 * Add `init_from_hashmap` to initialize config from `HashMap<String, String>` in unit tests
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ```rust
 [dependencies]
-envconfig = "0.10.0"
+envconfig = "0.10.1"
 ```
 
 ## Usage

--- a/envconfig/Cargo.toml
+++ b/envconfig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envconfig"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Sergey Potapov <blake131313@gmail.com>"]
 description = "Build a config structure from environment variables without boilerplate."
 categories = ["config", "web-programming"]
@@ -15,4 +15,4 @@ edition = "2018"
 [dev-dependencies]
 
 [dependencies]
-envconfig_derive = { version = "0.10.0", path = "../envconfig_derive" }
+envconfig_derive = { version = "0.10.1", path = "../envconfig_derive" }

--- a/envconfig_derive/Cargo.toml
+++ b/envconfig_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envconfig_derive"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Sergey Potapov <blake131313@gmail.com>"]
 description = "Build a config structure from environment variables without boilerplate."
 categories = ["config", "web-programming"]
@@ -16,6 +16,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = "1.0.17"
-quote = "1.0.3"
-proc-macro2 = "1.0.9"
+syn = "1.0.109"
+quote = "1.0.27"
+proc-macro2 = "1.0.58"

--- a/test_suite/tests/env_prefix.rs
+++ b/test_suite/tests/env_prefix.rs
@@ -1,0 +1,52 @@
+extern crate envconfig;
+
+use envconfig::{Envconfig};
+use std::env;
+
+#[derive(Envconfig)]
+#[envconfig(env_prefix = "TEST_")]
+pub struct ConfigWithoutFrom {
+    pub db_host: String,
+    pub db_port: u16,
+}
+
+fn setup() {
+    env::remove_var("TEST_DB_HOST");
+    env::remove_var("TEST_DB_PORT");
+}
+
+#[test]
+fn test_init_from_env_with_env_prefix_and_no_envconfig_on_attributes() {
+    setup();
+
+    env::set_var("TEST_DB_HOST", "localhost");
+    env::set_var("TEST_DB_PORT", "5432");
+
+
+    let config = ConfigWithoutFrom::init_from_env().unwrap();
+    assert_eq!(config.db_host, "localhost");
+    assert_eq!(config.db_port, 5432u16);
+}
+
+#[derive(Envconfig)]
+#[envconfig(env_prefix = "TEST_")]
+pub struct ConfigWithFrom {
+    #[envconfig(from = "DB_HOST")]
+    pub db_host: String,
+
+    #[envconfig(from = "DB_PORT")]
+    pub db_port: u16,
+}
+
+#[test]
+fn test_init_from_env_with_env_prefix_and_envconfig_on_attributes() {
+    setup();
+
+    env::set_var("TEST_DB_HOST", "localhost");
+    env::set_var("TEST_DB_PORT", "5433");
+
+
+    let config = ConfigWithFrom::init_from_env().unwrap();
+    assert_eq!(config.db_host, "localhost");
+    assert_eq!(config.db_port, 5433u16);
+}


### PR DESCRIPTION
Hello, I am new to Rust and thought of this feature while using it for another training project.
This should allow to parse environment variables that have a common prefix without having to use that prefix in every variables.

I also took the liberty to update the dependencies to their latest version, except for `syn` because it would require more work, because i feel like it's always better to have the latest updates for any dependencies if it might improve performance or patch some security issues.

I'll gladly take any input if the code, or even the logic, can be improved in any way.