### PR TITLE
Migrate to syn v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
-members = [
-    "envconfig",
-    "envconfig_derive",
-    "test_suite"
-]
+resolver = "2"
+members = ["envconfig", "envconfig_derive", "test_suite"]
+
+[workspace.package]
+edition = "2021"
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+
+[workspace.lints.clippy]
+pedantic = "warn"

--- a/envconfig/Cargo.toml
+++ b/envconfig/Cargo.toml
@@ -7,12 +7,11 @@ categories = ["config", "web-programming"]
 keywords = ["config", "env", "macro", "configuration", "environment"]
 license = "MIT"
 repository = "https://github.com/greyblake/envconfig-rs"
-homepage = "https://github.com/greyblake/envconfig-rs"
-documentation = "https://docs.rs/envconfig"
 readme = "README.md"
-edition = "2018"
+edition.workspace = true
 
-[dev-dependencies]
+[lints]
+workspace = true
 
 [dependencies]
 envconfig_derive = { version = "0.10.0", path = "../envconfig_derive" }

--- a/envconfig/src/error.rs
+++ b/envconfig/src/error.rs
@@ -1,5 +1,6 @@
-use std::error::Error as StdError;
-use std::fmt;
+//! Errors resulting from calling functions in this crate
+
+use std::{error::Error as StdError, fmt};
 
 /// Represents an error, that may be returned by `fn init_from_env()` of trait `Envconfig`.
 #[derive(Debug, PartialEq)]
@@ -11,7 +12,9 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::EnvVarMissing { name } => write!(f, "Environment variable {} is missing", name),
+            Error::EnvVarMissing { name } => {
+                write!(f, "Environment variable {} is missing", name)
+            }
             Error::ParseError { name } => {
                 write!(f, "Failed to parse environment variable {}", name)
             }

--- a/envconfig/src/error.rs
+++ b/envconfig/src/error.rs
@@ -13,10 +13,10 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::EnvVarMissing { name } => {
-                write!(f, "Environment variable {} is missing", name)
+                write!(f, "Environment variable {name} is missing")
             }
             Error::ParseError { name } => {
-                write!(f, "Failed to parse environment variable {}", name)
+                write!(f, "Failed to parse environment variable {name}")
             }
         }
     }

--- a/envconfig/src/lib.rs
+++ b/envconfig/src/lib.rs
@@ -25,7 +25,7 @@
 //! env::set_var("DB_PORT", "5432");
 //!
 //! // Initialize config from environment variables
-//! let config = Config::init().unwrap();
+//! let config = Config::init_from_env().unwrap();
 //!
 //! assert_eq!(config.db_host, "localhost");
 //! assert_eq!(config.db_port, Some(5432));

--- a/envconfig/src/traits.rs
+++ b/envconfig/src/traits.rs
@@ -4,7 +4,11 @@ use std::collections::HashMap;
 /// Indicates that structure can be initialize from environment variables.
 pub trait Envconfig {
     /// Initialize structure from environment variables.
-    /// Deprecated in favor of init_from_env().
+    /// Deprecated in favor of [`::init_from_env()`].
+    ///
+    /// # Errors
+    /// - Environment variable is missing.
+    /// - Failed to parse environment variable.
     #[deprecated(
         since = "0.9.0",
         note = "Function init() is deprecated. Please use init_from_env() instead."
@@ -14,11 +18,19 @@ pub trait Envconfig {
         Self: Sized;
 
     /// Initialize structure from environment variables.
+    ///
+    /// # Errors
+    /// - Environment variable is missing.
+    /// - Failed to parse environment variable.
     fn init_from_env() -> Result<Self, Error>
     where
         Self: Sized;
 
     /// Initialize structure from a hashmap.
+    ///
+    /// # Errors
+    /// - Environment variable is missing.
+    /// - Failed to parse environment variable.
     fn init_from_hashmap(hashmap: &HashMap<String, String>) -> Result<Self, Error>
     where
         Self: Sized;

--- a/envconfig/src/utils.rs
+++ b/envconfig/src/utils.rs
@@ -5,18 +5,19 @@ use crate::error::Error;
 use std::collections::HashMap;
 
 /// Load an environment variable by name and parse it into type `T`.
-/// The function is used by `envconfig_derive` to implement `init()`.
 ///
-/// It returns `Error` in the following cases:
+/// This function can also use a hashmap as a fallback or for testing purposes.
+///
+/// # Errors
 /// - Environment variable is not present
 /// - Parsing failed
-pub fn load_var<T: FromStr>(
+pub fn load_var<T: FromStr, S: ::std::hash::BuildHasher>(
     var_name: &'static str,
-    hashmap: Option<&HashMap<String, String>>,
+    hashmap: Option<&HashMap<String, String, S>>,
 ) -> Result<T, Error> {
     match hashmap {
         None => env::var(var_name).ok(),
-        Some(hashmap) => hashmap.get(var_name).map(|val| val.to_string()),
+        Some(hashmap) => hashmap.get(var_name).map(std::string::ToString::to_string),
     }
     .ok_or(Error::EnvVarMissing { name: var_name })
     .and_then(|string_value| {
@@ -26,14 +27,21 @@ pub fn load_var<T: FromStr>(
     })
 }
 
-pub fn load_var_with_default<T: FromStr>(
+/// Tries to load an environment variable by name and parse it into type `T`.
+/// If the environment variable is not present, it returns a default value.
+///
+/// This function can also use a hashmap as a fallback or for testing purposes.
+///
+/// # Errors
+/// - Parsing failed
+pub fn load_var_with_default<T: FromStr, S: ::std::hash::BuildHasher>(
     var_name: &'static str,
-    hashmap: Option<&HashMap<String, String>>,
+    hashmap: Option<&HashMap<String, String, S>>,
     default: &'static str,
 ) -> Result<T, Error> {
     let opt_var = match hashmap {
         None => env::var(var_name).ok(),
-        Some(hashmap) => hashmap.get(var_name).map(|val| val.to_string()),
+        Some(hashmap) => hashmap.get(var_name).map(std::string::ToString::to_string),
     };
 
     let string_value = match opt_var {
@@ -46,13 +54,20 @@ pub fn load_var_with_default<T: FromStr>(
         .map_err(|_| Error::ParseError { name: var_name })
 }
 
-pub fn load_optional_var<T: FromStr>(
+/// Tries to load an environment variable by name and parse it into type `T`.
+/// If the environment variable is not present, it returns `None`.
+///
+/// This function can also use a hashmap as a fallback or for testing purposes.
+///
+/// # Errors
+/// - Parsing failed
+pub fn load_optional_var<T: FromStr, S: ::std::hash::BuildHasher>(
     var_name: &'static str,
-    hashmap: Option<&HashMap<String, String>>,
+    hashmap: Option<&HashMap<String, String, S>>,
 ) -> Result<Option<T>, Error> {
     let opt_var = match hashmap {
         None => env::var(var_name).ok(),
-        Some(hashmap) => hashmap.get(var_name).map(|val| val.to_string()),
+        Some(hashmap) => hashmap.get(var_name).map(std::string::ToString::to_string),
     };
 
     match opt_var {

--- a/envconfig/src/utils.rs
+++ b/envconfig/src/utils.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use crate::error::Error;
 use std::collections::HashMap;
 
-/// Load a nenvironment variable by name and parse it into type `T`.
+/// Load an environment variable by name and parse it into type `T`.
 /// The function is used by `envconfig_derive` to implement `init()`.
 ///
 /// It returns `Error` in the following cases:

--- a/envconfig_derive/Cargo.toml
+++ b/envconfig_derive/Cargo.toml
@@ -17,6 +17,6 @@ workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.76", features = ["parsing", "derive"] }
+syn = { version = "2.0.77", features = ["parsing", "derive"] }
 quote = { version = "1.0.37", features = [] }
 proc-macro2 = { version = "1.0.86", features = [] }

--- a/envconfig_derive/Cargo.toml
+++ b/envconfig_derive/Cargo.toml
@@ -7,15 +7,16 @@ categories = ["config", "web-programming"]
 keywords = ["config", "env", "macro", "configuration", "environment"]
 license = "MIT"
 repository = "https://github.com/greyblake/envconfig-rs"
-homepage = "https://github.com/greyblake/envconfig-rs"
-documentation = "https://docs.rs/envconfig_derive"
 readme = "README.md"
-edition = "2018"
+edition.workspace = true
+
+[lints]
+workspace = true
 
 [lib]
 proc-macro = true
 
 [dependencies]
-syn = "1.0.17"
-quote = "1.0.3"
-proc-macro2 = "1.0.9"
+syn = { version = "2.0.76", features = ["parsing", "derive"] }
+quote = { version = "1.0.37", features = [] }
+proc-macro2 = { version = "1.0.86", features = [] }

--- a/envconfig_derive/src/lib.rs
+++ b/envconfig_derive/src/lib.rs
@@ -97,8 +97,12 @@ fn gen_field_assign(field: &Field, source: &Source) -> proc_macro2::TokenStream 
 
         // If nested attribute is present
         let nested_value_opt = find_item_in_list(&list, "nested");
-        if nested_value_opt.is_present() {
-            return gen_field_assign_for_struct_type(field, source);
+        match nested_value_opt {
+            MatchingItem::NoValue => return gen_field_assign_for_struct_type(field, source),
+            MatchingItem::WithValue(_) => {
+                panic!("`nested` attribute must not have a value")
+            }
+            MatchingItem::None => {}
         }
 
         // Default value for the field
@@ -260,15 +264,6 @@ enum MatchingItem<'a> {
     WithValue(&'a Lit),
     NoValue,
     None,
-}
-
-impl<'a> MatchingItem<'a> {
-    fn is_present(&self) -> bool {
-        match self {
-            MatchingItem::WithValue(_) | MatchingItem::NoValue => true,
-            MatchingItem::None => false,
-        }
-    }
 }
 
 /// Tries to find the first matching item in the provided list

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -2,6 +2,10 @@
 name = "envconfig_test_suite"
 version = "0.2.0"
 authors = ["Sergey Potapov <blake131313@gmail.com>"]
+edition.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 envconfig = { path = "../envconfig" }

--- a/test_suite/src/main.rs
+++ b/test_suite/src/main.rs
@@ -16,5 +16,5 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 fn main() {
     let res: Result<i32> = Ok(123);
-    println!("{:?}", res);
+    println!("{res:?}");
 }

--- a/test_suite/tests/nested.rs
+++ b/test_suite/tests/nested.rs
@@ -14,16 +14,16 @@ pub struct DBConfig {
 
 #[derive(Envconfig)]
 pub struct Config {
-    #[envconfig(nested = true)]
+    #[envconfig(nested)]
     pub db: DBConfig,
 }
 
 #[derive(Envconfig)]
 pub struct ConfigDouble {
-    #[envconfig(nested = true)]
+    #[envconfig(nested)]
     pub db1: DBConfig,
 
-    #[envconfig(nested = true)]
+    #[envconfig(nested)]
     pub db2: DBConfig,
 }
 


### PR DESCRIPTION
First of all thank you for this crate.

# The things I changed
1. update `syn` crate to v2: a lot of rewriting because of the new api and the dropped support for `NestedMeta`
2. Rust edition 2021
3. Fixed pedantic clippy warnings
4. Lots of docstrings

# Breaking changes
I think it would be more ergonomic to write `nested` instead of `nested = true` but this would result in a breaking api change. I'm not quite sure if this part is worth the change.

# Tests
All tests are passing and clippy doesn't emit any warning or error