### PR TITLE
feat: add prefix support to nested fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,39 @@ pub struct Config {
 }
 ```
 
+### Nested configs with prefix
+
+You can also nest configs with a prefix, which will strip the prefix from environment variables before passing them to the nested config. This is useful for grouping related environment variables.
+
+```rust
+#[derive(Envconfig)]
+pub struct DbConfig {
+    #[envconfig(from = "HOST")]  // Will use DB_HOST from environment
+    pub host: String,
+
+    #[envconfig(from = "PORT", default = "5432")]  // Will use DB_PORT from environment
+    pub port: u16,
+}
+
+#[derive(Envconfig)]
+pub struct CacheConfig {
+    #[envconfig(from = "HOST")]  // Will use CACHE_HOST from environment
+    pub host: String,
+
+    #[envconfig(from = "PORT", default = "6379")]  // Will use CACHE_PORT from environment
+    pub port: u16,
+}
+
+#[derive(Envconfig)]
+pub struct Config {
+    #[envconfig(nested, prefix = "DB_")]     // <---
+    db: DbConfig,
+
+    #[envconfig(nested, prefix = "CACHE_")]  // <---
+    cache: CacheConfig,
+}
+```
+
 
 ### Custom types
 

--- a/envconfig/src/lib.rs
+++ b/envconfig/src/lib.rs
@@ -32,6 +32,40 @@
 //! assert_eq!(config.http_port, 8080);
 //! ```
 //!
+//! ## Nested Configuration with Prefixes
+//!
+//! You can also nest configuration structures with prefixes:
+//!
+//! ```
+//! use std::env;
+//! use envconfig::Envconfig;
+//!
+//! #[derive(Envconfig)]
+//! struct DbConfig {
+//!     #[envconfig(from = "HOST")]  // Will look for DB_HOST
+//!     pub host: String,
+//!
+//!     #[envconfig(from = "PORT")]  // Will look for DB_PORT
+//!     pub port: u16,
+//! }
+//!
+//! #[derive(Envconfig)]
+//! struct Config {
+//!     #[envconfig(nested, prefix = "DB_")]
+//!     pub db: DbConfig,
+//! }
+//!
+//! // Set environment variables with prefixes
+//! env::set_var("DB_HOST", "localhost");
+//! env::set_var("DB_PORT", "5432");
+//!
+//! // Initialize config from environment variables
+//! let config = Config::init_from_env().unwrap();
+//!
+//! assert_eq!(config.db.host, "localhost");
+//! assert_eq!(config.db.port, 5432);
+//! ```
+//!
 //! The library uses `std::str::FromStr` trait to convert environment variables into custom
 //! data type. So, if your data type does not implement `std::str::FromStr` the program
 //! will not compile.

--- a/envconfig_derive/src/lib.rs
+++ b/envconfig_derive/src/lib.rs
@@ -172,8 +172,9 @@ fn gen_field_assign_for_struct_type(field: &Field, source: &Source, prefix: Opti
     
     match &field.ty {
         syn::Type::Path(path) => {
-            // If there's no prefix, use the simple form
-            if prefix.is_none() {
+            // Use pattern matching to handle the prefix
+            let Some(prefix_lit) = prefix else {
+                // If there's no prefix, use the simple form
                 return match source {
                     Source::Environment => quote! {
                         #ident: #path :: init_from_env()?
@@ -182,10 +183,10 @@ fn gen_field_assign_for_struct_type(field: &Field, source: &Source, prefix: Opti
                         #ident: #path :: init_from_hashmap(hashmap)?
                     },
                 };
-            }
+            };
             
             // Otherwise, process with prefix
-            let prefix_str = match prefix.unwrap() {
+            let prefix_str = match prefix_lit {
                 Lit::Str(s) => s.value(),
                 _ => panic!("Expected prefix to be a string literal"),
             };

--- a/test_suite/tests/nested_prefix.rs
+++ b/test_suite/tests/nested_prefix.rs
@@ -1,0 +1,145 @@
+extern crate envconfig;
+
+use envconfig::{Envconfig, Error};
+use std::collections::HashMap;
+use std::env;
+
+#[derive(Envconfig)]
+pub struct DBConfig {
+    #[envconfig(from = "HOST")]
+    pub host: String,
+    #[envconfig(from = "PORT")]
+    pub port: u16,
+}
+
+#[derive(Envconfig)]
+pub struct Config {
+    #[envconfig(nested, prefix = "DB_")]
+    pub db: DBConfig,
+    
+    #[envconfig(nested, prefix = "CACHE_")]
+    pub cache: CacheConfig,
+}
+
+#[derive(Envconfig)]
+pub struct CacheConfig {
+    #[envconfig(from = "HOST")]
+    pub host: String,
+    
+    #[envconfig(from = "PORT", default = "6379")]
+    pub port: u16,
+}
+
+#[derive(Envconfig)]
+pub struct MultiConfig {
+    #[envconfig(nested, prefix = "DB1_")]
+    pub db1: DBConfig,
+
+    #[envconfig(nested, prefix = "DB2_")]
+    pub db2: DBConfig,
+}
+
+fn setup() {
+    // Clean up all environment variables we might use in tests
+    env::remove_var("DB_HOST");
+    env::remove_var("DB_PORT");
+    env::remove_var("CACHE_HOST");
+    env::remove_var("CACHE_PORT");
+    env::remove_var("DB1_HOST");
+    env::remove_var("DB1_PORT");
+    env::remove_var("DB2_HOST");
+    env::remove_var("DB2_PORT");
+}
+
+#[test]
+fn test_nested_prefix_env() {
+    setup();
+
+    env::set_var("DB_HOST", "localhost");
+    env::set_var("DB_PORT", "5432");
+    env::set_var("CACHE_HOST", "redis");
+    // CACHE_PORT uses default value
+
+    let config = Config::init_from_env().unwrap();
+    assert_eq!(config.db.host, "localhost");
+    assert_eq!(config.db.port, 5432u16);
+    assert_eq!(config.cache.host, "redis");
+    assert_eq!(config.cache.port, 6379u16);
+}
+
+#[test]
+fn test_nested_prefix_hashmap() {
+    setup();
+
+    let mut hashmap = HashMap::new();
+    hashmap.insert("DB_HOST".to_string(), "localhost".to_string());
+    hashmap.insert("DB_PORT".to_string(), "5432".to_string());
+    hashmap.insert("CACHE_HOST".to_string(), "redis".to_string());
+    // CACHE_PORT uses default value
+
+    let config = Config::init_from_hashmap(&hashmap).unwrap();
+    assert_eq!(config.db.host, "localhost");
+    assert_eq!(config.db.port, 5432u16);
+    assert_eq!(config.cache.host, "redis");
+    assert_eq!(config.cache.port, 6379u16);
+}
+
+#[test]
+fn test_nested_prefix_env_error() {
+    setup();
+
+    env::set_var("DB_HOST", "localhost");
+    env::set_var("CACHE_HOST", "redis");
+    // DB_PORT is missing
+
+    let err = Config::init_from_env().err().unwrap();
+    let expected_err = Error::EnvVarMissing { name: "PORT" };
+    assert_eq!(err, expected_err);
+}
+
+#[test]
+fn test_nested_prefix_hashmap_error() {
+    setup();
+
+    let mut hashmap = HashMap::new();
+    hashmap.insert("DB_HOST".to_string(), "localhost".to_string());
+    hashmap.insert("CACHE_HOST".to_string(), "redis".to_string());
+    // DB_PORT is missing
+
+    let err = Config::init_from_hashmap(&hashmap).err().unwrap();
+    let expected_err = Error::EnvVarMissing { name: "PORT" };
+    assert_eq!(err, expected_err);
+}
+
+#[test]
+fn test_multiple_nested_prefix_env() {
+    setup();
+
+    env::set_var("DB1_HOST", "primary");
+    env::set_var("DB1_PORT", "5432");
+    env::set_var("DB2_HOST", "replica");
+    env::set_var("DB2_PORT", "5433");
+
+    let config = MultiConfig::init_from_env().unwrap();
+    assert_eq!(config.db1.host, "primary");
+    assert_eq!(config.db1.port, 5432u16);
+    assert_eq!(config.db2.host, "replica");
+    assert_eq!(config.db2.port, 5433u16);
+}
+
+#[test]
+fn test_multiple_nested_prefix_hashmap() {
+    setup();
+
+    let mut hashmap = HashMap::new();
+    hashmap.insert("DB1_HOST".to_string(), "primary".to_string());
+    hashmap.insert("DB1_PORT".to_string(), "5432".to_string());
+    hashmap.insert("DB2_HOST".to_string(), "replica".to_string());
+    hashmap.insert("DB2_PORT".to_string(), "5433".to_string());
+
+    let config = MultiConfig::init_from_hashmap(&hashmap).unwrap();
+    assert_eq!(config.db1.host, "primary");
+    assert_eq!(config.db1.port, 5432u16);
+    assert_eq!(config.db2.host, "replica");
+    assert_eq!(config.db2.port, 5433u16);
+}


### PR DESCRIPTION
Hi there, first of all thanks for this crate.

I'm opening a PR for supporting prefixing in nested structures. So it differs by #43 since that one supports prefixes on the structs themselves.

It solves a pain point in one of my codebases that we can't reuse structures:
```rust
#[derive(Envconfig)]
pub struct DbConfig {
    #[envconfig(from = "HOST")]
    pub host: String,
    #[envconfig(from = "PORT", default = "5432")]
    pub port: u16,
}

#[derive(Envconfig)]
pub struct Config {
    #[envconfig(nested)]
    pub foo: DbConfig,
    #[envconfig(nested)]
    pub bar: DbConfig,
}
```

In this example, I'd have to create another identical DbConfig struct for each database. But with this PR, we can reuse it:

```rust
#[derive(Envconfig)]
pub struct DbConfig {
    #[envconfig(from = "HOST")]
    pub host: String,
    #[envconfig(from = "PORT", default = "5432")]
    pub port: u16,
}

#[derive(Envconfig)]
pub struct Config {
    #[envconfig(nested, prefix = "FOO_")]
    pub foo: DbConfig,
    #[envconfig(nested, prefix = "BAR_")]
    pub bar: DbConfig,
}
```